### PR TITLE
chore(vendor): pocketjs b87b537 — DevTools on the desktop host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 crates/openstrike-psp/target/
 # script/e2e outputs
 /out/
+/pocketjs-dbg/


### PR DESCRIPTION
Pins the engine at pocket-stack/pocketjs#73: `pocket-ui-wgpu` now mounts the DevTools debug ops + a file-mailbox transport, so the **desktop** build gets the full DevTools loop on macOS:

```sh
bun run devtools --dir ~/code/open-strike --port 8131   # in pocketjs
cargo run --release -p openstrike -- --maps-dir …        # from this repo root
```

Verified live on this machine: `hello{host:"desktop"}`, tree streaming from frame 1, `inspect` drawing the core highlight in the 1600×900 window, pause/resume — while a real-PSP session streamed its own tree on port 8130 in parallel.

No pixel impact (the shim change only adds a transport-side host label); PSP goldens stay valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)