### PR TITLE
perf(vita): move world rendering onto GXM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1629,6 +1629,7 @@ dependencies = [
  "png",
  "pocket3d-bsp",
  "pollster",
+ "serde_json",
  "wgpu",
  "winit",
 ]

--- a/crates/openstrike-vita/src/main.rs
+++ b/crates/openstrike-vita/src/main.rs
@@ -35,6 +35,88 @@ mod vita {
     #[cfg(feature = "capture")]
     const CAPTURE_ROOT: &str = "ux0:data/openstrike-vita/cap";
 
+    #[cfg(feature = "bench")]
+    struct BenchWindow {
+        frames: u64,
+        frame_sum_us: u64,
+        cpu_sum_us: u64,
+        render_sync_sum_us: u64,
+        max_frame_us: u64,
+        max_cpu_us: u64,
+        max_render_sync_us: u64,
+    }
+
+    #[cfg(feature = "bench")]
+    struct BenchSample {
+        frames: u64,
+        elapsed_us: u64,
+        avg_frame_us: u64,
+        max_frame_us: u64,
+        avg_cpu_us: u64,
+        max_cpu_us: u64,
+        avg_render_sync_us: u64,
+        max_render_sync_us: u64,
+    }
+
+    #[cfg(feature = "bench")]
+    impl BenchWindow {
+        fn new() -> Self {
+            Self {
+                frames: 0,
+                frame_sum_us: 0,
+                cpu_sum_us: 0,
+                render_sync_sum_us: 0,
+                max_frame_us: 0,
+                max_cpu_us: 0,
+                max_render_sync_us: 0,
+            }
+        }
+
+        fn record(
+            &mut self,
+            frame_started_us: u64,
+            render_started_us: u64,
+            frame_finished_us: u64,
+        ) -> Option<BenchSample> {
+            let frame_us = frame_finished_us.saturating_sub(frame_started_us);
+            let cpu_us = render_started_us.saturating_sub(frame_started_us);
+            // Includes the previous-frame GXM drain in begin_frame and any
+            // swap/vblank pacing in present; it is deliberately not labelled
+            // as pure CPU render or GPU execution time.
+            let render_sync_us = frame_finished_us.saturating_sub(render_started_us);
+            self.frame_sum_us += frame_us;
+            self.cpu_sum_us += cpu_us;
+            self.render_sync_sum_us += render_sync_us;
+            self.max_frame_us = self.max_frame_us.max(frame_us);
+            self.max_cpu_us = self.max_cpu_us.max(cpu_us);
+            self.max_render_sync_us = self.max_render_sync_us.max(render_sync_us);
+            self.frames += 1;
+            if self.frames < 300 {
+                return None;
+            }
+
+            let elapsed_us = self.frame_sum_us.max(1);
+            let sample = BenchSample {
+                frames: self.frames,
+                elapsed_us,
+                avg_frame_us: elapsed_us / self.frames,
+                max_frame_us: self.max_frame_us,
+                avg_cpu_us: self.cpu_sum_us / self.frames,
+                max_cpu_us: self.max_cpu_us,
+                avg_render_sync_us: self.render_sync_sum_us / self.frames,
+                max_render_sync_us: self.max_render_sync_us,
+            };
+            self.frames = 0;
+            self.frame_sum_us = 0;
+            self.cpu_sum_us = 0;
+            self.render_sync_sum_us = 0;
+            self.max_frame_us = 0;
+            self.max_cpu_us = 0;
+            self.max_render_sync_us = 0;
+            Some(sample)
+        }
+    }
+
     #[no_mangle]
     #[used]
     pub static sceUserMainThreadStackSize: u32 = 2 * 1024 * 1024;
@@ -94,15 +176,28 @@ mod vita {
         index: u32,
         world_faces: u32,
         world_tris: u32,
+        world_direct_draw_calls: u32,
+        geometry_resident: bool,
+        geometry_error: Option<&str>,
+        texture_error: Option<pocket3d_vita::texture::UploadError>,
         frame_pool: &FramePool,
         camera: &Camera3d,
     ) -> Result<(), String> {
         let image = format!("{CAPTURE_ROOT}/f{index:04}.rgba");
         unsafe { runtime.capture_golden(&image) }.map_err(|error| error.to_string())?;
+        let gxm_error = unsafe { pocket3d_vita::last_gxm_error() }.unwrap_or("none");
+        let geometry_error = geometry_error.unwrap_or("none");
+        let texture_error = texture_error
+            .map(|error| format!("{error:?}"))
+            .unwrap_or_else(|| "none".to_string());
         let scene = format!(
-            "world_faces={world_faces}\nworld_tris={world_tris}\nsubmitted_tris={}\ndraw_calls={}\ncamera_yaw={}\ncamera_pitch={}\n",
+            "renderer=gxm\ngxm_error={gxm_error}\ngeometry_resident={}\ngeometry_error={geometry_error}\ntexture_error={texture_error}\nworld_faces={world_faces}\nworld_tris={world_tris}\nworld_direct_draw_calls={world_direct_draw_calls}\nsubmitted_tris={}\ndraw_calls={}\ndropped_triangles={}\nsubmission_errors={}\neffect_tris={}\ncamera_yaw={}\ncamera_pitch={}\n",
+            u8::from(geometry_resident),
             frame_pool.last.triangles,
             frame_pool.last.draw_calls,
+            frame_pool.last.dropped_triangles,
+            frame_pool.last.submission_errors,
+            frame_pool.last.additive_triangles,
             camera.yaw,
             camera.pitch,
         );
@@ -147,8 +242,11 @@ mod vita {
         let sky = SkyParams::default();
         let rifle = present_data::build_rifle();
         let bot_body = present_data::build_bot_body();
+        let mut effect_geometry = present_data::EffectGeometry::default();
         let mut menu_time = 0.0f64;
         let mut frame = 0u32;
+        #[cfg(feature = "bench")]
+        let mut bench_window = BenchWindow::new();
 
         #[cfg(feature = "capture")]
         let capture_script = CaptureScript::parse(CAPTURE_INPUT);
@@ -160,6 +258,8 @@ mod vita {
         let mut capture_complete = false;
 
         loop {
+            #[cfg(feature = "bench")]
+            let bench_frame_started = vitasdk_sys::sceKernelGetProcessTimeWide();
             let physical = input::read();
             let physical = PadSample {
                 buttons: physical.buttons,
@@ -203,6 +303,8 @@ mod vita {
             strike::drain_host(|command| host_command = Some(command));
             runtime.tick();
 
+            #[cfg(feature = "bench")]
+            let bench_render_started = vitasdk_sys::sceKernelGetProcessTimeWide();
             graphics::begin_frame(0xff00_0000);
             frame_pool.reset();
             let camera = match &game {
@@ -223,39 +325,96 @@ mod vita {
             if let Some(current) = &mut game {
                 current.world.draw(&mut frame_pool, &camera);
                 present_data::draw_bots(&mut frame_pool, &bot_body, &current.sim.bots);
-                present_data::draw_effects(&mut frame_pool, &current.sim, camera.forward());
+                present_data::draw_effects(
+                    &mut frame_pool,
+                    &mut effect_geometry,
+                    &current.sim,
+                    camera.forward(),
+                );
                 present_data::draw_viewmodel(&mut frame_pool, &rifle, &current.sim);
             }
             pocket3d_vita::end_3d();
             runtime.render_over();
             graphics::present();
 
+            #[cfg(feature = "bench")]
+            if let Some(sample) = bench_window.record(
+                bench_frame_started,
+                bench_render_started,
+                vitasdk_sys::sceKernelGetProcessTimeWide(),
+            ) {
+                let (faces, triangles, world_draws) = game
+                    .as_ref()
+                    .map(|current| {
+                        (
+                            current.world.last_faces,
+                            current.world.last_tris,
+                            current.world.last_direct_draw_calls,
+                        )
+                    })
+                    .unwrap_or((0, 0, 0));
+                let fps_x100 = sample.frames.saturating_mul(100_000_000) / sample.elapsed_us;
+                vita_log(format_args!(
+                    "[OpenStrike Vita] bench frames={} fps={}.{:02} avg_frame_us={} max_frame_us={} avg_cpu_us={} max_cpu_us={} avg_render_sync_us={} max_render_sync_us={} faces={} world_tris={} world_direct_draw_calls={} submitted_tris={} draw_calls={} dropped_tris={} submission_errors={}",
+                    sample.frames,
+                    fps_x100 / 100,
+                    fps_x100 % 100,
+                    sample.avg_frame_us,
+                    sample.max_frame_us,
+                    sample.avg_cpu_us,
+                    sample.max_cpu_us,
+                    sample.avg_render_sync_us,
+                    sample.max_render_sync_us,
+                    faces,
+                    triangles,
+                    world_draws,
+                    frame_pool.last.triangles,
+                    frame_pool.last.draw_calls,
+                    frame_pool.last.dropped_triangles,
+                    frame_pool.last.submission_errors,
+                ));
+            }
+
             #[cfg(feature = "capture")]
             if !capture_complete && frame >= cap_start && frame < cap_start.saturating_add(cap_n) {
                 let index = frame - cap_start;
-                let (faces, triangles) = game
+                let (
+                    faces,
+                    triangles,
+                    gpu_draw_calls,
+                    geometry_resident,
+                    geometry_error,
+                    texture_error,
+                ) = game
                     .as_ref()
-                    .map(|current| (current.world.last_faces, current.world.last_tris))
-                    .unwrap_or((0, 0));
-                dump_capture(&mut runtime, index, faces, triangles, &frame_pool, &camera)
-                    .unwrap_or_else(|error| fail(&error));
+                    .map(|current| {
+                        (
+                            current.world.last_faces,
+                            current.world.last_tris,
+                            current.world.last_direct_draw_calls,
+                            current.world.gpu_geometry_resident(),
+                            current.world.geometry_error(),
+                            current.world.last_texture_error,
+                        )
+                    })
+                    .unwrap_or((0, 0, 0, false, None, None));
+                dump_capture(
+                    &mut runtime,
+                    index,
+                    faces,
+                    triangles,
+                    gpu_draw_calls,
+                    geometry_resident,
+                    geometry_error,
+                    texture_error,
+                    &frame_pool,
+                    &camera,
+                )
+                .unwrap_or_else(|error| fail(&error));
                 if index + 1 == cap_n {
                     let _ = std::fs::write(format!("{CAPTURE_ROOT}/done"), b"ok\n");
                     capture_complete = true;
                 }
-            }
-
-            #[cfg(feature = "bench")]
-            if frame > 0 && frame % 300 == 0 {
-                let (faces, triangles) = game
-                    .as_ref()
-                    .map(|current| (current.world.last_faces, current.world.last_tris))
-                    .unwrap_or((0, 0));
-                vita_log(format_args!(
-                    "[OpenStrike Vita] frame={frame} faces={faces} world_tris={triangles} submitted_tris={} draw_calls={}",
-                    frame_pool.last.triangles,
-                    frame_pool.last.draw_calls,
-                ));
             }
 
             // Host intents are applied outside every renderer/map borrow. A

--- a/crates/openstrike-vita/src/present_data.rs
+++ b/crates/openstrike-vita/src/present_data.rs
@@ -11,7 +11,9 @@ use glam::Vec3;
 use openstrike_core::weapon::{rifle_boxes, FxBeam, FxSprite, GUN_COLORS};
 use openstrike_core::StrikeSim;
 #[cfg(target_os = "vita")]
-use pocket3d_vita::mesh::{clear_depth_for_viewmodel, draw_color_tris, ColorVert};
+use pocket3d_vita::mesh::{
+    clear_depth_for_viewmodel, draw_additive_tris, draw_color_tris, ColorVert,
+};
 #[cfg(target_os = "vita")]
 use pocket3d_vita::FramePool;
 
@@ -31,6 +33,8 @@ pub struct ColorVertex {
 #[derive(Default)]
 pub struct EffectGeometry {
     pub vertices: Vec<ColorVertex>,
+    sprites: Vec<FxSprite>,
+    beams: Vec<FxBeam>,
 }
 
 fn abgr(rgba: [u8; 4], brightness: f32) -> u32 {
@@ -38,8 +42,8 @@ fn abgr(rgba: [u8; 4], brightness: f32) -> u32 {
     0xff00_0000 | (channel(rgba[2]) << 16) | (channel(rgba[1]) << 8) | channel(rgba[0])
 }
 
-fn abgr_f(color: [f32; 4], scale: f32) -> u32 {
-    let channel = |value: f32| ((value * scale).clamp(0.0, 1.0) * 255.0) as u32;
+fn abgr_f(color: [f32; 4]) -> u32 {
+    let channel = |value: f32| (value.clamp(0.0, 1.0) * 255.0) as u32;
     (channel(color[3]) << 24)
         | (channel(color[2]) << 16)
         | (channel(color[1]) << 8)
@@ -196,36 +200,44 @@ pub fn build_bot_body() -> Vec<ColorVertex> {
 
 /// Build camera-facing quads for the current muzzle/tracer/impact effects.
 pub fn build_effects(sim: &StrikeSim, camera_forward: Vec3) -> EffectGeometry {
-    let mut sprites: Vec<FxSprite> = Vec::new();
-    let mut beams: Vec<FxBeam> = Vec::new();
-    sim.effects.emit(&mut sprites, &mut beams);
-    let mut vertices = Vec::with_capacity((sprites.len() + beams.len()) * 6);
+    let mut geometry = EffectGeometry::default();
+    build_effects_into(&mut geometry, sim, camera_forward);
+    geometry
+}
+
+/// Like [`build_effects`], reusing the buffers retained in `out`.
+pub fn build_effects_into(out: &mut EffectGeometry, sim: &StrikeSim, camera_forward: Vec3) {
+    out.sprites.clear();
+    out.beams.clear();
+    sim.effects.emit(&mut out.sprites, &mut out.beams);
+    let vertices = &mut out.vertices;
+    vertices.clear();
+    vertices.reserve((out.sprites.len() + out.beams.len()) * 6);
 
     let right = camera_forward.cross(Vec3::Y).normalize_or_zero();
     let up = right.cross(camera_forward);
-    for sprite in sprites {
+    for sprite in &out.sprites {
         let radius_right = right * (sprite.size * 0.5);
         let radius_up = up * (sprite.size * 0.5);
         add_quad(
-            &mut vertices,
+            vertices,
             [
                 sprite.pos - radius_right - radius_up,
                 sprite.pos + radius_right - radius_up,
                 sprite.pos + radius_right + radius_up,
                 sprite.pos - radius_right + radius_up,
             ],
-            abgr_f(sprite.color, sprite.color[3]),
+            abgr_f(sprite.color),
         );
     }
-    for beam in beams {
+    for beam in &out.beams {
         let side = (beam.b - beam.a).cross(camera_forward).normalize_or_zero() * (beam.width * 0.5);
         add_quad(
-            &mut vertices,
+            vertices,
             [beam.a - side, beam.b - side, beam.b + side, beam.a + side],
-            abgr_f(beam.color, beam.color[3]),
+            abgr_f(beam.color),
         );
     }
-    EffectGeometry { vertices }
 }
 
 /// Queue every actor body using the shared simulation transform.
@@ -248,9 +260,14 @@ pub unsafe fn draw_bots(pool: &mut FramePool, body: &[ColorVertex], bots: &[open
 /// A `pocket3d_vita` pass must be active and `pool` must remain stable until
 /// `pocket3d_vita::end_3d` flushes it.
 #[cfg(target_os = "vita")]
-pub unsafe fn draw_effects(pool: &mut FramePool, sim: &StrikeSim, camera_forward: Vec3) {
-    let effects = build_effects(sim, camera_forward);
-    unsafe { draw_color_tris(pool, &effects.vertices, Mat4::IDENTITY) };
+pub unsafe fn draw_effects(
+    pool: &mut FramePool,
+    geometry: &mut EffectGeometry,
+    sim: &StrikeSim,
+    camera_forward: Vec3,
+) {
+    build_effects_into(geometry, sim, camera_forward);
+    unsafe { draw_additive_tris(pool, &geometry.vertices, Mat4::IDENTITY) };
 }
 
 /// Queue the first-person rifle on a later painter layer so walls cannot
@@ -282,5 +299,66 @@ mod tests {
         assert!(!rifle.is_empty());
         assert_eq!(rifle.len() % 3, 0);
         assert_eq!(bot.len(), 7 * 6 * 6);
+    }
+
+    #[test]
+    fn effect_colors_keep_straight_alpha() {
+        assert_eq!(abgr_f([1.0, 0.5, 0.25, 0.5]), 0x7f3f_7fff);
+    }
+
+    #[test]
+    fn effect_scratch_buffers_are_reused_and_cleared() {
+        let mut sim = StrikeSim::new(Vec3::ZERO, 0.0, Vec::new(), 0);
+        sim.effects.spawn(
+            openstrike_core::weapon::EffectKind::MuzzleFlash { pos: Vec3::ZERO },
+            1.0,
+        );
+        sim.effects.spawn(
+            openstrike_core::weapon::EffectKind::Tracer {
+                a: Vec3::ZERO,
+                b: Vec3::NEG_Z,
+            },
+            1.0,
+        );
+        let mut geometry = EffectGeometry::default();
+        build_effects_into(&mut geometry, &sim, Vec3::NEG_Z);
+        assert_eq!(geometry.vertices.len(), 12);
+        assert_eq!(geometry.sprites.len(), 1);
+        assert_eq!(geometry.beams.len(), 1);
+        let pointers = (
+            geometry.vertices.as_ptr(),
+            geometry.sprites.as_ptr(),
+            geometry.beams.as_ptr(),
+        );
+        let capacities = (
+            geometry.vertices.capacity(),
+            geometry.sprites.capacity(),
+            geometry.beams.capacity(),
+        );
+
+        build_effects_into(&mut geometry, &sim, Vec3::NEG_Z);
+        assert_eq!(
+            pointers,
+            (
+                geometry.vertices.as_ptr(),
+                geometry.sprites.as_ptr(),
+                geometry.beams.as_ptr(),
+            )
+        );
+        assert_eq!(
+            capacities,
+            (
+                geometry.vertices.capacity(),
+                geometry.sprites.capacity(),
+                geometry.beams.capacity(),
+            )
+        );
+
+        sim.effects.clear();
+        build_effects_into(&mut geometry, &sim, Vec3::NEG_Z);
+        assert!(geometry.vertices.is_empty());
+        assert!(geometry.sprites.is_empty());
+        assert!(geometry.beams.is_empty());
+        assert_eq!(geometry.vertices.capacity(), capacities.0);
     }
 }

--- a/crates/openstrike/src/main.rs
+++ b/crates/openstrike/src/main.rs
@@ -67,6 +67,7 @@ fn main() -> Result<()> {
             size: WINDOW_SIZE,
             tick_hz: 64.0,
             capture_mouse: true,
+            ..AppConfig::default()
         },
         Windowed { game, strike, guest_error: None },
     )

--- a/scripts/e2e-vita.ts
+++ b/scripts/e2e-vita.ts
@@ -307,9 +307,14 @@ function assertNativeDetail(raw: Buffer, label: string): void {
 interface SceneTelemetry {
   cameraYaw: number;
   cameraPitch: number;
+  effectTriangles: number;
 }
 
-function assertLiveScene(scenePath: string, label: string): SceneTelemetry {
+function assertLiveScene(
+  scenePath: string,
+  label: string,
+  expectEffects: boolean,
+): SceneTelemetry {
   if (!existsSync(scenePath)) throw new Error(`${label}: scene sidecar missing`);
   const values = Object.fromEntries(
     readFileSync(scenePath, "utf8")
@@ -317,18 +322,63 @@ function assertLiveScene(scenePath: string, label: string): SceneTelemetry {
       .split("\n")
       .map((line) => line.split("=", 2)),
   );
-  for (const field of ["world_faces", "world_tris", "submitted_tris", "draw_calls"]) {
+  if (values.renderer !== "gxm") {
+    throw new Error(`${label}: expected renderer=gxm, got ${values.renderer ?? "missing"}`);
+  }
+  for (const field of ["gxm_error", "geometry_error", "texture_error"]) {
+    if (values[field] !== "none") {
+      throw new Error(`${label}: ${field}=${values[field] ?? "missing"}`);
+    }
+  }
+  for (const field of [
+    "geometry_resident",
+    "world_faces",
+    "world_tris",
+    "world_direct_draw_calls",
+    "submitted_tris",
+    "draw_calls",
+  ]) {
     const value = Number(values[field]);
     if (!Number.isFinite(value) || value <= 0) {
       throw new Error(`${label}: ${field} must be positive, got ${values[field] ?? "missing"}`);
     }
+  }
+  if (Number(values.geometry_resident) !== 1) {
+    throw new Error(`${label}: geometry_resident must be 1`);
+  }
+  for (const field of ["dropped_triangles", "submission_errors"]) {
+    if (Number(values[field]) !== 0) {
+      throw new Error(`${label}: ${field} must be zero, got ${values[field] ?? "missing"}`);
+    }
+  }
+  const worldTriangles = Number(values.world_tris);
+  const submittedTriangles = Number(values.submitted_tris);
+  const drawCalls = Number(values.draw_calls);
+  if (submittedTriangles < worldTriangles) {
+    throw new Error(
+      `${label}: submitted_tris ${submittedTriangles} is below world_tris ${worldTriangles}`,
+    );
+  }
+  // The old CPU-projected backend emitted almost one draw per triangle. The
+  // indexed GXM backend must retain a wide batching margin on this fixed map.
+  if (drawCalls * 8 >= submittedTriangles) {
+    throw new Error(
+      `${label}: ${drawCalls} draws for ${submittedTriangles} triangles misses the GXM batching budget`,
+    );
+  }
+  const effectTriangles = Number(values.effect_tris);
+  if (!Number.isFinite(effectTriangles) || effectTriangles < 0) {
+    throw new Error(`${label}: invalid effect_tris=${values.effect_tris ?? "missing"}`);
+  }
+  if (expectEffects && effectTriangles <= 0) {
+    throw new Error(`${label}: scripted fire frame submitted no additive effect triangles`);
   }
   const cameraYaw = Number(values.camera_yaw);
   const cameraPitch = Number(values.camera_pitch);
   if (!Number.isFinite(cameraYaw) || !Number.isFinite(cameraPitch)) {
     throw new Error(`${label}: finite camera_yaw/camera_pitch telemetry is required`);
   }
-  return { cameraYaw, cameraPitch };
+  return { cameraYaw, cameraPitch, effectTriangles };
 }
 
 function assertLookProbe(
@@ -395,7 +445,10 @@ for (const spec of selectedSpecs) {
     try {
       const raw = readFileSync(rawPath);
       assertNativeDetail(raw, label);
-      telemetry.set(shot, assertLiveScene(`${capDir}/${stem}.scene`, label));
+      telemetry.set(
+        shot,
+        assertLiveScene(`${capDir}/${stem}.scene`, label, spec.name === "fire"),
+      );
 
       const png = `${outDir}/${label}.png`;
       await $`magick -size 960x544 -depth 8 RGBA:${rawPath} -alpha off -define png:exclude-chunks=date,time PNG24:${png}`.quiet();


### PR DESCRIPTION
## Summary

- update the Vita engine pin and move static world rendering onto PocketJS's resident GXM backend
- reuse effect geometry buffers and submit muzzle/tracer effects with additive blending
- add 300-frame wall-clock/CPU/render-sync telemetry and renderer health counters
- strengthen Vita3K capture E2E to require GXM residency, batching, zero drops/errors, camera motion, and fire effects

Depends on pocket-stack/pocketjs#144.

## Validation

- `bun run typecheck`
- `bun run check:platforms`
- `bun run test:vita-package` (2/2)
- `bun test test/psp-toolchain.test.ts` (16/16)
- `cargo test --workspace`
- `cargo test --manifest-path crates/openstrike-vita/Cargo.toml` (12/12)
- PocketJS Vita backend tests (13/13)
- Pocket3D BSP tests (9 unit + 4 real-map cases)
- release Vita ARM cross-build with `bench,capture`
- full Vita3K E2E: spawn 4/4, walk 44/44, fire 12/12; byte-exact scripted input, resident geometry, zero dropped triangles/submission errors
- final non-capture release VPK built and archive-validated locally

## Device follow-up

Real Vita performance/visual validation remains intentionally outstanding. In particular, masked cutouts use the stock libvita2d alpha-blended shader because it has no alpha discard; fence/effect occlusion should be inspected on hardware.
